### PR TITLE
docs: add requirements and quickstart guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,69 @@ cd ios-security-analyzer
 python3 -m pip install psutil
 python3 ios_security_analyzer.py
 ```
+
+---
+
+## 🛡️ Security Audit Plan (Best-Practice Order)
+Below is a practical, risk-based order you can follow **first-to-last**.
+
+### Phase 1 — Preparation & Scoping (Week 1-2)
+Start here to avoid audit chaos and rework.
+
+1. **Define scope clearly**
+   - In-scope: cloud/on-prem, endpoints, applications, vendors, physical controls.
+   - Out-of-scope: document exclusions (e.g., legacy systems being decommissioned).
+2. **Identify critical assets**
+   - Prioritize customer data, payment systems, identity systems, and core infrastructure.
+3. **Map compliance obligations**
+   - Use only what applies (GDPR, HIPAA, PCI DSS, NIST, ISO 27001).
+4. **Assemble a hybrid team**
+   - Internal: CISO/security/IT/compliance/legal.
+   - External: independent auditor + penetration testing/red team.
+5. **Select frameworks**
+   - Primary: **NIST CSF**.
+   - Supporting: CIS Controls + OWASP Top 10 + industry-specific standards.
+
+### Phase 2 — Execution by Category (Week 3-8)
+Run checks in this order for best risk reduction early.
+
+1. **Identity & Access Control (highest priority)**
+   - MFA for privileged users, least-privilege RBAC, dormant account cleanup, PAM visibility.
+2. **Network Security**
+   - Firewall rule review, IDS/IPS validation, secure VPN/TLS, segmentation effectiveness.
+3. **Endpoint & Patch Security**
+   - EDR status, missing patches, disk encryption, MDM policy quality.
+4. **Data Protection**
+   - Encryption at rest/in transit, DLP checks, backup + restore validation.
+5. **Application & API Security**
+   - SDLC review, OWASP checks, API auth/rate limits, WAF effectiveness.
+6. **Logging, Monitoring & Detection**
+   - SIEM coverage, alert tuning, retention policy, privileged event monitoring.
+7. **Third-Party / Supply Chain Security**
+   - Vendor risk assessments, SBOM/code-signing/dependency integrity checks.
+8. **Physical Security & Governance**
+   - Facility access controls, disposal procedures, policy + training + tabletop readiness.
+
+### Phase 3 — Reporting & Remediation (Week 9-10)
+1. Build a severity-ranked report (Critical/High/Medium/Low).
+2. Create owner-assigned remediation with deadlines (e.g., 7/30/60/90 days).
+3. Fix quick wins first:
+   - enforce MFA,
+   - patch critical vulnerabilities,
+   - disable dormant accounts.
+4. Re-test high-risk findings to verify closure.
+
+### Phase 4 — Continuous Improvement (Ongoing)
+1. **Audit cadence**: annual full audit + quarterly high-risk reviews.
+2. **Automate where possible**: SIEM, vulnerability scanning, policy compliance checks.
+3. **Train people continuously**: security awareness + role-specific technical training.
+4. **Track KPIs**:
+   - % critical findings closed within SLA,
+   - MTTD/MTTR,
+   - compliance coverage,
+   - phishing-resilience and false-positive reduction.
+
+### Recommended rollout strategy (most practical)
+- **Pilot first** on one high-risk system.
+- Expand after lessons learned.
+- Keep the approach **risk-based** to balance security and operational stability.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,50 @@
-# 🔴 Albania Blood Cybersecurity - iOS Security Analyzer 🔴
-### **"Your iOS Security Guardian - Advanced Forensic &amp; Threat Analysis for iOS**
+# 🔴 Albania Blood Cybersecurity - iOS Security Analyzer
+### **Your iOS Security Guardian - Advanced Forensic & Threat Analysis for iOS**
 ### **Advanced iOS Cybersecurity & Pentesting Tool**
 
 ![Security](https://img.shields.io/badge/security-high-green) ![License](https://img.shields.io/badge/license-MIT-blue)
 
 ## 📌 About
-**iOS Security Analyzer** is a high-level penetration testing and security auditing tool designed for **iSH on iOS**. It allows users to scan system information, analyze running processes, detect Wi-Fi networks, and generate detailed security reports.
+**iOS Security Analyzer** is a penetration testing and security auditing tool designed for **iSH on iOS**. It can collect system information, inspect running processes, attempt Wi-Fi scanning, and export a basic security report.
 
 ## 🚀 Features
-✅ **Automated Security Auditing**  
-✅ **System Information Analysis**  
-✅ **Process Monitoring (CPU & RAM usage)**  
-✅ **Wi-Fi Network Scanning (Jailbreak/Root required)**  
-✅ **Security Report Generation (Export logs)**  
+- ✅ Automated security auditing
+- ✅ System information analysis
+- ✅ Process monitoring (CPU & RAM usage)
+- ✅ Wi-Fi network scanning (when available)
+- ✅ Security report generation (export logs)
 
-## 📥 Installation
-1. **Clone the repository:**
-   ```sh
-   git clone https://github.com/youh4ck3dme/ios-security-analyzer.git
-   cd ios-security-analyzer
+## ✅ Requirements
+- **Python:** Python **3.8+** is recommended.
+- **Python package:** `psutil` must be installed.
+- **Wi-Fi scanner dependency:** Wi-Fi scanning uses `nmcli` (`nmcli dev wifi`).
+  - On most **iOS/iSH** environments, `nmcli` is missing or blocked by sandbox limitations.
+  - If `nmcli` is unavailable, the tool will show:
+    - `Wi-Fi scan unavailable on iOS sandbox.`
 
-# 
+### Interpreting Wi-Fi scan output
+- If actual network rows are shown, scanning worked in your environment.
+- If you only see `Wi-Fi scan unavailable on iOS sandbox.`, this is expected on restricted iOS setups and **does not mean the script crashed**.
+- Report generation still works; only the Wi-Fi section is limited.
 
+## ⚡ Quickstart
+```sh
+# 1) (Optional) create and activate a virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# 2) Install dependencies
+python3 -m pip install --upgrade pip
+python3 -m pip install psutil
+
+# 3) Run the analyzer
+python3 ios_security_analyzer.py
+```
+
+## 📥 Installation (Git)
+```sh
+git clone https://github.com/youh4ck3dme/ios-security-analyzer.git
+cd ios-security-analyzer
+python3 -m pip install psutil
+python3 ios_security_analyzer.py
+```


### PR DESCRIPTION
### Motivation
- Clarify runtime requirements and external dependencies so users can prepare an environment that can run the analyzer reliably.
- Explain the expected behavior when Wi‑Fi scanning is unavailable on iOS/iSH so users do not mistake the limited output for a crash.

### Description
- Add a `Requirements` section specifying Python 3.8+, the `psutil` package, and that Wi‑Fi scanning relies on `nmcli` which is often missing/blocked on iOS/iSH.
- Add an `Interpreting Wi‑Fi scan output` section documenting the fallback message `Wi‑Fi scan unavailable on iOS sandbox.` and explaining that report generation still works.
- Add a minimal `Quickstart` command sequence to create a virtual environment, install dependencies, and run `ios_security_analyzer.py`, and update the Git-based installation example.

### Testing
- Verified the updated `README.md` contents with `nl -ba README.md` to confirm the new sections were added successfully.
- Committed the documentation change with `git add README.md` and `git commit -m "docs: add requirements and quickstart guidance"`, which completed successfully.
- No unit or runtime tests were required because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb02f5042c8333805483889003e6b8)